### PR TITLE
Fix protocol frame padding size

### DIFF
--- a/release/python/l2tester/packet.py
+++ b/release/python/l2tester/packet.py
@@ -72,11 +72,11 @@ def dot1q_summary(self):
 Dot1Q.mysummary = dot1q_summary
 
 def dot1q_post_build(self, packet, payload):
-	""" Implement post build to calculate length for 802.3 frame. 
+	""" Implement post build to calculate length for 802.3 frame.
 	"""
 	if self.type == None or self.type <= 1500 :
 		l = len(payload)
-		packet = packet[:2] + chr((l>>8)&0xff) + chr(l&0xff)
+		packet = packet[:2] + chr((l >> 8) & 0xff) + chr(l & 0xff)
 		self.type = l
 	return packet + payload
 
@@ -385,9 +385,9 @@ def protocol_frame(protocol, source='unicast', vlans = []):
 	pdu = pdu / info['load']
 
 	# Add Padding and return.
-	padding = 64 - len(pdu) + 4 #FCS
+	padding = 64 + (4 * len(vlans)) - len(pdu) + 4 #FCS
 	if padding > 0 :
-		pdu = pdu / Padding(load = '\0' * padding)
+		pdu = pdu / Raw('\0' * padding)
 
 	#Process PDU so length field is correctly calculated.
 	pdu = Ether(str(pdu))


### PR DESCRIPTION
Since VLAN tags can be added or removed by any switch in the path of the
packet, ignore VLAN tags from padding size to ensure that the packet
will pass through all network devices.

Also change paddind method to Raw() due to issues with size of packets
in Dot1Q frames. Padding() is not counted in the frame size if the LLC()
layer if added before a Dot1Q tag.

Signed-off-by: Filipe Utzig <filipeutzig@gmail.com>