### PR TITLE
Initial support to Python3

### DIFF
--- a/release/python/bin/shark
+++ b/release/python/bin/shark
@@ -61,8 +61,8 @@ class Receiver(l2tester.Sniffer):
         @param filter        Index of the filter that matched the packet.
         @param packet        Packet data.
         """
-        print "\033[1m[%s]\033[0m %s \033[2m(%d bytes)\033[0m" % (
-            self.names[iface], Ether(packet).summary(), len(packet) + 4)
+        print("\033[1m[%s]\033[0m %s \033[2m(%d bytes)\033[0m" % (
+            self.names[iface], Ether(packet).summary(), len(packet) + 4))
         if self.hexdump_enabled:
             hexdump(packet)
         return True

--- a/release/python/bin/sharknado
+++ b/release/python/bin/sharknado
@@ -201,7 +201,7 @@ class QRxStream(QObject):
     def add_stream(self, add):
 
         if add:
-            print "Adding Stream..."
+            print("Adding Stream...")
             try:
                 self.instance = eval("self.sniffer.instance.new_stream(%s)" %
                                      self.filter_args.text())
@@ -212,7 +212,7 @@ class QRxStream(QObject):
                 QMessageBox.critical(None, QString("Can't create RxStream"), QString(str(exp)))
 
         else:
-            print "Removing Stream..."
+            print("Removing Stream...")
             self.sniffer.instance.delete_stream(self.instance)
             self.instance = None
             self.add.setText('Add')
@@ -257,11 +257,11 @@ class QMonitor(QGridLayout):
     def create_sniffer(self, create):
 
         if create:
-            print "Creating Monitor..."
+            print("Creating Monitor...")
             try:
                 iface_list = map(lambda i: i.strip(), str(self.ifaces.text()).split(','))
-                print " * interfaces: " + str(iface_list)
-                print " * interval: " + str(self.interval.text())
+                print(" * interfaces: " + str(iface_list))
+                print(" * interval: " + str(self.interval.text()))
                 self.instance = Monitor(iface_list, float(self.interval.text()))
                 self.create.setText('Destroy')
                 self.emit(SIGNAL("created(bool)"), True)
@@ -271,7 +271,7 @@ class QMonitor(QGridLayout):
                 QMessageBox.critical(None, QString("Can't create Monitor"), QString(str(exp)))
 
         else:
-            print "Destroy Monitor..."
+            print("Destroy Monitor...")
             self.instance.stop()
             self.instance = None
 
@@ -283,7 +283,7 @@ class QMonitor(QGridLayout):
     def start_sniffer(self, start):
 
         if start:
-            print "Starting Monitor..."
+            print("Starting Monitor...")
             if self.instance:
                 self.instance.start()
                 self.start.setText('Stop')
@@ -292,7 +292,7 @@ class QMonitor(QGridLayout):
                 self.start.setChecked(False)
 
         else:
-            print "Stopping Monitor..."
+            print("Stopping Monitor...")
             self.instance.stop()
             self.start.setText('Start')
             self.emit(SIGNAL("started(bool)"), False)
@@ -364,7 +364,7 @@ class QSender(QObject):
     def start_bandwidth(self, start):
 
         if start:
-            print "Starting Bandwidth from interface " + self.iface.text() + " ..."
+            print("Starting Bandwidth from interface " + self.iface.text() + " ...")
             try:
                 self.packet = eval(str(self.frame.text()))
                 self.instance = Sender(str(self.iface.text()), self.packet)
@@ -379,7 +379,7 @@ class QSender(QObject):
                 QMessageBox.critical(None, QString("Can't start Sender"), QString(str(exp)))
         else:
             self.start.setText('Start')
-            print "Stopping Bandwidth..."
+            print("Stopping Bandwidth...")
             self.instance.stop()
             self.instance = None
 

--- a/release/python/l2tester/interface.py
+++ b/release/python/l2tester/interface.py
@@ -244,7 +244,7 @@ class Interface():
         @param enable        True to enable, False to disable.
         """
         cmd = PACKET_ADD_MEMBERSHIP if enable else PACKET_DROP_MEMBERSHIP
-        mreq = struct.pack('IHH8s', self.if_index, PACKET_MR_PROMISC, 0, "")
+        mreq = struct.pack('IHH8s', self.if_index, PACKET_MR_PROMISC, 0, bytes())
         self.sockfd.setsockopt(SOL_PACKET, cmd, mreq)
 
     def add_ip_address(self, ip_address):

--- a/release/python/l2tester/packet.py
+++ b/release/python/l2tester/packet.py
@@ -8,7 +8,7 @@ from scapy.layers.inet import IP, ICMP
 from scapy.layers.inet6 import IPv6
 from scapy.utils import checksum
 
-from interface import mac_address
+from .interface import mac_address
 from ipaddress import ip_address
 
 ## Class MAC Address ##############################################################################

--- a/swig/l2tester_python.i
+++ b/swig/l2tester_python.i
@@ -25,5 +25,5 @@
 
 %typemap(directorin) (void* _packet, size_t _size)
 %{
-    $input = PyString_FromStringAndSize( (char*) _packet, _size );
+    $input = PyBytes_FromStringAndSize( (char*) _packet, _size );
 %}


### PR DESCRIPTION
This commit starts the support of a Py2/Py3 compatible version of the
L2tester, initial tests verify that the `shark` application is able to
start and minimally run on a Dockerized Python3.8-based container.
Further tests will be required in order to verify full feature support.

Signed-off-by: Filipe Utzig <filipeutzig@gmail.com>